### PR TITLE
RDKB-58602: [OneWifi]: MultiVAP, WiFi Backhaul as AL_MAC

### DIFF
--- a/build/linux/EasymeshCfg.json
+++ b/build/linux/EasymeshCfg.json
@@ -1,0 +1,16 @@
+{
+    "_comment": [
+        "This is a sample JSON file of Easymesh configuration to be read by OneWifi",
+        "and will be configured in /nvram as part of either",
+        " a) Wifi-reset by the controller, in case of collocated agent OR",
+        " b) as part of DPP Onboarding, in case of remote agent.",
+        "The AL_MAC_ADDR is the mac address of interface on which IEEE1905 packets are transmitted",
+        "Colocated_mode is to indicate whether OneWifi is part of local or remote agent."
+        "The backhaul SSID and KeyPassphrase will be used for configuring Mesh backhaul",
+        "or connecting to Mesh backhaul in case of backhaul STA"
+    ],
+    "AL_MAC_ADDR":  "d8:3a:dd:a2:05:5c",
+    "Colocated_mode": 0,
+    "Backhaul_SSID": "Mesh_Backhaul",
+    "Backhaul_KeyPassphrase": "test-backhaul"
+}

--- a/build/linux/MultiVap_InterfaceMap.json
+++ b/build/linux/MultiVap_InterfaceMap.json
@@ -1,0 +1,82 @@
+{
+    "_comment": [
+        "This is a sample JSON configuration for Raspberry PI with below assumptions:",
+        " 1) External USB wifi adapter being used is Canakit usb wifi adapter, which supports 8 2.4G VAPs.",
+        "     Link: https://www.canakit.com/raspberry-pi-wifi.html",
+        " 2) Interfaces specified in InterfaceName have already been created seperately and",
+        "     this file is only providing the interface mapping associated for that interface.",
+        " 3) Built in Wifi of Rpi is using interface wlan0.",
+        "Some details on the outline of the elements:",
+        "PhyList is an array of phys supported on device with Index specifying the actual phy index.",
+        "Each phy has an array of RadioList which depicts the radios supported on that phy.",
+        "The index in the RadioList specifies the radio type 0 means 2.4G, 1 means 5G and 2 means 6G.",
+        "The RadioName in the RadioList specifies the primary interface associate with that radio.",
+        "The fields in InterfaceList is self-explanatory with vapName specifying the type of VAP."
+    ],
+    "PhyList": [
+        {
+            "Index": 0,
+            "RadioList": [
+                {
+                    "Index": 1,
+                    "RadioName": "wlan0",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wlan0",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 1,
+                            "vapName": "private_ssid_5g"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Index": 1,
+            "RadioList": [
+                {
+                    "Index": 0,
+                    "RadioName": "wlan1",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wlan1.1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 2,
+                            "vapName": "private_ssid_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1.2",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 3,
+                            "vapName": "iot_ssid_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1.3",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 4,
+                            "vapName": "lnf_psk_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1.4",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 5,
+                            "vapName": "mesh_backhaul_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 0,
+                            "vapName": "mesh_sta_2g"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/build/linux/create_virtual_intf.sh
+++ b/build/linux/create_virtual_intf.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#This file creates virtual interfaces on the primary interface passed in argument#1
+#The number of interfaces created is specified in argument#2.
+
+#check whether number of input argument is 2
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <primary_interface> <number_of_interfaces>"
+    exit 1
+fi
+
+primary_intf=$1
+num_intf=$2
+
+#check if primary interface exists before proceeding
+if [ ! -e "/sys/class/net/$primary_intf" ]; then
+    echo "Error: Primary interface $primary_intf does not exist"
+    exit 1
+fi
+
+# Create virtual interfaces
+for i in $(seq 1 $num_intf); do
+    virtual_intf="${primary_intf}.$i"
+    sudo iw dev "$primary_intf" interface add "$virtual_intf" type managed
+    if [ -e "/sys/class/net/$virtual_intf" ]; then
+        echo "Created virtual interface: $virtual_intf"
+        sudo ifconfig "$virtual_intf" down
+    else
+        echo "Error: Unable to create virtual interface: $virtual_intf"
+        exit 1
+    fi
+done
+
+echo "Created $num_intf virtual interfaces based on $primary_intf"

--- a/build/linux/makefile
+++ b/build/linux/makefile
@@ -457,3 +457,7 @@ run:
 setup:
 	./build/linux/setup.sh
 
+vapsetup:
+	cp ./build/linux/MultiVap_InterfaceMap.json /nvram/InterfaceMap.json
+	cp ./build/linux/EasymeshCfg.json /nvram/EasymeshCfg.json
+	./build/linux/create_virtual_intf.sh wlan1 4

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -277,7 +277,8 @@ bool is_sta_enabled(void)
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     //wifi_util_dbg_print(WIFI_CTRL,"[%s:%d] device mode:%d active_gw_check:%d\r\n",
     //    __func__, __LINE__, ctrl->network_mode, ctrl->active_gw_check);
-    return ((ctrl->network_mode == rdk_dev_mode_type_ext || ctrl->active_gw_check == true) &&
+    return ((ctrl->network_mode == rdk_dev_mode_type_ext ||
+                ctrl->network_mode == rdk_dev_mode_type_em_node || ctrl->active_gw_check == true) &&
         ctrl->eth_bh_status == false);
 }
 
@@ -601,14 +602,25 @@ void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
     get_wifidb_obj()->desc.get_wifi_global_param_fn(&global_param);
     // set all default return values first
     if (strcmp(name, WIFI_DEVICE_MODE) == 0) {
-#ifdef EASY_MESH_NODE
-       wifi_util_info_print(WIFI_CTRL,"%s:%d\n",__func__,__LINE__);
-       *ret_val = (unsigned int)rdk_dev_mode_type_em_node;
-
-#elif EASY_MESH_COLOCATED_NODE
-       wifi_util_info_print(WIFI_CTRL,"%s:%d\n",__func__,__LINE__);
-       *ret_val = (unsigned int)rdk_dev_mode_type_em_colocated_node;
-
+#ifdef EASY_MESH_NODE || defined EASY_MESH_COLOCATED_NODE
+        wifi_mgr_t *wifi_mgr = get_wifimgr_obj();
+        int colocated_mode = ((wifi_mgr_t *)get_wifimgr_obj())->hal_cap.wifi_prop.colocated_mode;
+        /* Initially assign this to em_node mode to start with */
+        *ret_val = (unsigned int)rdk_dev_mode_type_em_node;
+        while (colocated_mode == -1) {
+            /* sleep for 1 second and re-read the wifi_hal_getHalCapability till we get 
+               a valid colocated_mode */
+            sleep(1);
+            total_slept++;
+            wifi_hal_getHalCapability(&((wifi_mgr_t *)get_wifimgr_obj())->hal_cap);
+            colocated_mode = ((wifi_mgr_t *)get_wifimgr_obj())->hal_cap.wifi_prop.colocated_mode;
+        }
+        if (colocated_mode == 1) {
+            *ret_val = (unsigned int)rdk_dev_mode_type_em_colocated_node;
+        } else if (colocated_mode == 0) {
+            *ret_val = (unsigned int)rdk_dev_mode_type_em_node;
+        }
+        wifi_util_info_print(WIFI_CTRL, "%s:%d: network_mode:%d.\n", __func__, __LINE__, *ret_val);
 #else
        wifi_util_info_print(WIFI_CTRL,"%s:%d\n",__func__,__LINE__);
 #ifdef ONEWIFI_DEFAULT_NETWORKING_MODE
@@ -624,7 +636,6 @@ void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
 #else
         ctrl->dev_type = dev_subtype_rdk;
 #endif
-
     } else if (strcmp(name, WIFI_DEVICE_TUNNEL_STATUS) == 0) {
         *ret_val = DEVICE_TUNNEL_DOWN; // tunnel down
     }
@@ -818,6 +829,7 @@ int start_wifi_services(void)
     } else if (ctrl->network_mode == rdk_dev_mode_type_em_colocated_node) {
         wifi_util_info_print(WIFI_CTRL, "%s:%d start em_colocated mode\n",__func__, __LINE__);
         start_radios(rdk_dev_mode_type_gw);
+        start_gateway_vaps();
     }
 
     return RETURN_OK;
@@ -1030,7 +1042,8 @@ int scan_results_callback(int radio_index, wifi_bss_info_t **bss, unsigned int *
         res.num = *num;
         memcpy((unsigned char *)res.bss, (unsigned char *)(*bss), (*num)*sizeof(wifi_bss_info_t));
     }
-    if (ctrl->network_mode == rdk_dev_mode_type_ext) {
+    if (ctrl->network_mode == rdk_dev_mode_type_ext ||
+        ctrl->network_mode == rdk_dev_mode_type_em_node) {
         push_event_to_ctrl_queue(&res, sizeof(scan_results_t), wifi_event_type_hal_ind,
             wifi_event_scan_results, NULL);
     }

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -618,6 +618,66 @@ bus_error_t webconfig_get_dml_subdoc(char *event_name, raw_data_t *p_data)
     webconfig_subdoc_data_t data;
     wifi_mgr_t *mgr = (wifi_mgr_t *)get_wifimgr_obj();
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+    int vap_index;
+    wifi_back_haul_sta_t *sta_info;
+    wifi_platform_property_t *wifi_prop = &((wifi_mgr_t *)get_wifimgr_obj())->hal_cap.wifi_prop;
+    mac_address_t zero_mac;
+    char ifname[100] = {0};
+    int ret = 0;
+    mac_addr_str_t mac_str;
+
+    memset(zero_mac, 0, sizeof(mac_address_t));
+    /*
+      In case of Easymesh mode few checks should be done before the dml subdoc is sent.
+       1) Check al_mac address is non-zero and colocated_mode is either 0 or 1. If any of
+          them incorrect, return bus_error.
+       2) If colocated_mode is 0 then check whether configured al_mac has a valid interface
+          and if it is a interface in interface map should be a sta interface and should be
+          in connected state.
+    */
+    if (ctrl->network_mode == rdk_dev_mode_type_em_node ||
+        ctrl->network_mode == rdk_dev_mode_type_em_colocated_node) {
+        /* check 1 */
+        if (memcmp(wifi_prop->al_1905_mac, zero_mac, sizeof(mac_address_t)) == 0 ||
+            wifi_prop->colocated_mode == -1) {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d FATAL Error al_mac:%s or colocated_mode:%d incorrect\n", __func__, __LINE__,
+                to_mac_str(wifi_prop->al_1905_mac, mac_str), wifi_prop->colocated_mode);
+            return bus_error_access_not_allowed;
+        }
+        /* check 2 */
+        if (wifi_prop->colocated_mode == 0) {
+            /* colocated_mode 0 check ifname is sta and connected*/
+            ret = interfacename_from_mac(wifi_prop->al_1905_mac, ifname);
+            if (ret != 0) {
+                wifi_util_error_print(WIFI_CTRL,
+                    "%s:%d FATAL Error Interface not found for al_mac:%s\n", __func__, __LINE__,
+                    to_mac_str(wifi_prop->al_1905_mac, mac_str));
+                return bus_error_access_not_allowed;
+            }
+            vap_index = convert_ifname_to_vap_index(wifi_prop, ifname);
+            if (vap_index != -1) {
+                sta_info = get_wifi_object_sta_parameter(vap_index);
+                if (sta_info == NULL || sta_info->conn_status != wifi_connection_status_connected) {
+                    wifi_util_error_print(WIFI_CTRL,
+                        "%s:%d Error backhaul interface:%p is not sta interface or not connected, "
+                        "conn_status:%d\n",
+                        __func__, __LINE__, sta_info,
+                        (sta_info == NULL) ? 0 : sta_info->conn_status);
+                    return bus_error_access_not_allowed;
+                }
+            } else {
+                /* check the interface name before treating it as error */
+                if (strncmp(ifname, "eth", strlen("eth")) != 0 &&
+                    strncmp(ifname, "lo", strlen("lo")) != 0) {
+                    wifi_util_error_print(WIFI_CTRL,
+                        "%s:%d Error ifname:%s is not ethernet or loopback interface.\n", __func__,
+                        __LINE__, ifname);
+                    return bus_error_access_not_allowed;
+                }
+            }
+        }
+    }
 
     memset(&data, 0, sizeof(webconfig_subdoc_data_t));
     memcpy((unsigned char *)&data.u.decoded.radios, (unsigned char *)&mgr->radio_config,
@@ -638,7 +698,7 @@ bus_error_t webconfig_get_dml_subdoc(char *event_name, raw_data_t *p_data)
     p_data->data_type = bus_data_type_string;
     p_data->raw_data.bytes = malloc(str_size);
     if (p_data->raw_data.bytes == NULL) {
-        wifi_util_error_print(WIFI_CTRL,"%s:%d memory allocation is failed:%d\r\n",__func__,
+        wifi_util_error_print(WIFI_CTRL, "%s:%d memory allocation is failed:%d\r\n", __func__,
             __LINE__, str_size);
         return bus_error_out_of_resources;
     }

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -317,26 +317,7 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         }
 
         cfg.u.sta_info.scan_params.channel.band = band;
-
-        switch(band) {
-            case WIFI_FREQUENCY_2_4_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 1;
-                break;
-            case WIFI_FREQUENCY_5_BAND:
-            case WIFI_FREQUENCY_5L_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 44;
-                break;
-            case WIFI_FREQUENCY_5H_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 157;
-                break;
-            case WIFI_FREQUENCY_6_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 5;
-                break;
-            default:
-                wifi_util_error_print(WIFI_DB,"%s:%d invalid band %d\n", __func__, __LINE__, band);
-                break;
-        }
-
+        cfg.u.sta_info.scan_params.channel.channel = 0;
         cfg.u.sta_info.conn_status = wifi_connection_status_disabled;
         memset(&cfg.u.sta_info.bssid, 0, sizeof(cfg.u.sta_info.bssid));
     } else {
@@ -427,7 +408,7 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.beaconRate = WIFI_BITRATE_6MBPS;
         strncpy(cfg.u.bss_info.beaconRateCtl,"6Mbps",sizeof(cfg.u.bss_info.beaconRateCtl)-1);
         cfg.vap_mode = wifi_vap_mode_ap;
-        if (isVapPrivate(vap_index)) {
+        if (isVapPrivate(vap_index) || isVapMeshBackhaul(vap_index)) {
             cfg.u.bss_info.showSsid = true;
             cfg.u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_PUSHBUTTON;
             memset(wps_pin, 0, sizeof(wps_pin));
@@ -443,8 +424,9 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         } else {
             cfg.u.bss_info.showSsid = false;
         }
-        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
-             cfg.u.bss_info.enabled = true;
+        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index) ||
+            isVapMeshBackhaul(vap_index) || isVapXhs(vap_index)) {
+            cfg.u.bss_info.enabled = true;
         }
 
         if (isVapPrivate(vap_index)) {
@@ -457,7 +439,6 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
 
         if (wifi_hal_get_default_ssid(ssid, vap_index) == 0) {
             strcpy(cfg.u.bss_info.ssid, ssid);
-
         } else {
            strcpy(cfg.u.bss_info.ssid, vap_name);
         }
@@ -647,7 +628,59 @@ void wifidb_print(char *format, ...)
 int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
     rdk_wifi_vap_info_t *rdk_config)
 {
-    return 0;
+    wifi_platform_property_t *wifi_prop = NULL;
+    int ret = RETURN_OK;
+
+    wifi_prop = &((wifi_mgr_t *)get_wifimgr_obj())->hal_cap.wifi_prop;
+    if (vap_name == NULL || config == NULL || wifi_prop == NULL) {
+        wifi_util_error_print(WIFI_DB, "%s:%d Failed to Get VAP info - Null pointer\n", __func__,
+            __LINE__);
+        return RETURN_ERR;
+    }
+    config->vap_index = convert_vap_name_to_index(wifi_prop, vap_name);
+    config->radio_index = convert_vap_name_to_radio_array_index(wifi_prop, vap_name);
+    strncpy(config->vap_name, vap_name, (sizeof(config->vap_name) - 1));
+    ret = get_bridgename_from_vapname(wifi_prop, vap_name, config->bridge_name,
+        sizeof(config->bridge_name));
+
+    rdk_config->exists = TRUE;
+
+    if (isVapSTAMesh(config->vap_index)) {
+        strncpy(config->u.sta_info.ssid, "Mesh_Backhaul", (sizeof(config->u.sta_info.ssid) - 1));
+        config->u.sta_info.enabled = TRUE;
+        config->u.sta_info.scan_params.period = 10;
+        config->u.sta_info.scan_params.channel.channel = 0;
+        config->u.sta_info.scan_params.channel.band = WIFI_FREQUENCY_2_4_BAND |
+            WIFI_FREQUENCY_5_BAND | WIFI_FREQUENCY_6_BAND;
+    } else {
+        strncpy(config->u.bss_info.ssid, "Mesh_Backhaul ", (sizeof(config->u.bss_info.ssid) - 1));
+        config->u.bss_info.enabled = TRUE;
+        config->u.bss_info.showSsid = TRUE;
+        config->u.bss_info.isolation = FALSE;
+        config->u.bss_info.mgmtPowerControl = 100;
+        config->u.bss_info.bssMaxSta = 32;
+        config->u.bss_info.bssTransitionActivated = FALSE;
+        config->u.bss_info.nbrReportActivated = FALSE;
+        config->u.bss_info.network_initiated_greylist = FALSE;
+        config->u.bss_info.connected_building_enabled = FALSE;
+        config->u.bss_info.rapidReconnectEnable = FALSE;
+        config->u.bss_info.rapidReconnThreshold = 0;
+        config->u.bss_info.vapStatsEnable = TRUE;
+        config->u.bss_info.mac_filter_enable = FALSE;
+        config->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
+        config->u.bss_info.wmm_enabled = TRUE;
+        config->u.bss_info.UAPSDEnabled = TRUE;
+        config->u.bss_info.beaconRate = WIFI_BITRATE_DEFAULT;
+        config->u.bss_info.wmmNoAck = 0;
+        config->u.bss_info.wepKeyLength = 0;
+        config->u.bss_info.bssHotspot = FALSE;
+        config->u.bss_info.wpsPushButton = FALSE;
+        config->u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_EASYCONNECT | WIFI_ONBOARDINGMETHODS_PUSHBUTTON;
+        config->u.bss_info.wps.enable = TRUE;
+        config->u.bss_info.hostap_mgt_frame_ctrl = TRUE;
+        config->u.bss_info.mbo_enabled = TRUE;
+    }
+    return ret;
 }
 
 int wifidb_update_wifi_macfilter_config(char *macfilter_key, acl_entry_t *config, bool add)

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -30,6 +30,12 @@
 #include <netinet/in.h>
 #include <time.h>
 #include <openssl/sha.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <linux/if_packet.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
 
 #define  ARRAY_SZ(x)    (sizeof(x) / sizeof((x)[0]))
 /* enable PID in debug logs */
@@ -4379,4 +4385,62 @@ int get_partner_id(char *partner_id)
     }
 
     return ret;
+}
+
+// This routine will take mac address from the user and returns interfacename
+int interfacename_from_mac(const mac_address_t *mac, char *ifname)
+{
+    struct ifaddrs *ifaddr = NULL, *tmp = NULL;
+    struct sockaddr *addr;
+    struct sockaddr_ll *ll_addr;
+    bool found = false;
+
+    if (getifaddrs(&ifaddr) != 0) {
+        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: Failed to get interfae information\n", __func__, __LINE__);
+        return -1;
+    }
+
+    tmp = ifaddr;
+    while (tmp != NULL) {
+        addr = tmp->ifa_addr;
+        ll_addr = (struct sockaddr_ll*)tmp->ifa_addr;
+        if ((addr != NULL) && (addr->sa_family == AF_PACKET) && (memcmp(ll_addr->sll_addr, mac, sizeof(mac_address_t)) == 0)) {
+            strncpy(ifname, tmp->ifa_name, strlen(tmp->ifa_name));
+            found = true;
+            break;
+        }
+
+        tmp = tmp->ifa_next;
+    }
+
+    freeifaddrs(ifaddr);
+
+    return (found == true) ? 0:-1;
+}
+
+// This routine will take interfacename and return mac address
+int mac_address_from_name(const char *ifname, mac_address_t mac)
+{
+    int sock;
+    struct ifreq ifr;
+
+    if ((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP)) < 0) {
+        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: Failed to create socket\n", __func__, __LINE__);
+        return -1;
+    }
+
+    memset(&ifr, 0, sizeof(struct ifreq));
+    ifr.ifr_addr.sa_family = AF_INET;
+    strcpy(ifr.ifr_name, ifname);
+    if (ioctl(sock, SIOCGIFHWADDR, &ifr) != 0) {
+        close(sock);
+        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: ioctl failed to get hardware address for interface:%s\n", __func__, __LINE__, ifname);
+        return -1;
+    }
+
+    memcpy(mac, (unsigned char *)ifr.ifr_hwaddr.sa_data, sizeof(mac_address_t));
+
+    close(sock);
+
+    return 0;
 }

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -393,6 +393,8 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
     rdk_wifi_vap_info_t *rdk_old, rdk_wifi_vap_info_t *rdk_new, bool isSta);
 int update_radio_operating_classes(wifi_radio_operationParam_t *oper);
 int get_partner_id(char *partner_id);
+int interfacename_from_mac(const mac_address_t *mac, char *ifname);
+int mac_address_from_name(const char *ifname, mac_address_t mac);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Reason for change: Support for configuring Onewifi to support below VAP configuration in Raspberry Pi
1) Private_5G using built-in Raspberry Pi Wifi adapter. 2) Raspberry Pi External Wifi adapter with SKU:RSP-PI-WIFI1 (Link: https://www.canakit.com/raspberry-pi-wifi.html) to support following VAP
	- Mesh sta backhaul 2G
	- Private_2G
	- Guest AP using iot_ssid vap
	- DPP configurator on lnf_psk vap
	- Mesh VAP backhaul 2G 3) Necessary sample Json file for multivap configuration 4) Linux Makefile change to include label "vapsetup" to copy the configuration to appropriate location.
5) Change for sending bus error message in case of wrong configuration, in easymesh mode or easymesh colocated mode based on almac address.

Test Procedure:
Tested configuration with Canakit adapter and almac address being set to eth0, wlan0. Requires additional dependent changes in rdk-wifi-hal, unified-wifi-mesh and halinterface for all the scenarios to work.